### PR TITLE
Add cloud build support

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,8 @@
+steps:
+- id: 'Stage app engine using mvn cloud image'
+  name: 'gcr.io/cloud-builders/mvn'
+  args: ['package', 'appengine:stage']
+- id: 'gcr.io/cloud-builders/gcloud'
+  name: 'gcr.io/cloud-builders/gcloud'
+  args: ['app', 'deploy', 'target/appengine-staging/app.yaml']
+timeout: "1600s"

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,6 @@ limitations under the License.
         <version>2.0.0-rc5</version>
 	<configuration>
 		<project>sp19-codeu-17-9747</project>
-		<version>1</version>
 	</configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@ limitations under the License.
     <dependency>
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-api-1.0-sdk</artifactId>
-      <version>1.9.59</version>
+      <version>1.9.71</version>
     </dependency>
 
     <dependency>
@@ -66,9 +66,13 @@ limitations under the License.
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.59</version>
+        <version>2.0.0-rc5</version>
+	<configuration>
+		<project>sp19-codeu-17-9747</project>
+		<version>1</version>
+	</configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
In order for all these fun moving parts to work, I needed to shift us to the 2.0 release candidate
for the App Engine maven plugin.  This translates to a few changes to how we run things for the project

mvn appengine:start  # to start up your dev server
mvn appengine:stop   # to stop it.

Once this is committed, we can enable a build hook against the master branch that automatically builds and deploys our service.

closes #24 